### PR TITLE
Improve Wayland paste flow after selection

### DIFF
--- a/clipmaster@gnome.extension/extension.js
+++ b/clipmaster@gnome.extension/extension.js
@@ -8,6 +8,7 @@
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 import St from 'gi://St';
+import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 
@@ -16,6 +17,7 @@ import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/
 
 import { SignalManager, ValidationUtils } from './src/Util/Utils.js';
 import { setDebugMode, debugLog } from './src/Util/Constants.js';
+import { getPasteKeySpec } from './src/Util/PasteUtils.js';
 import { ClipboardDatabase } from './src/Manager/Database.js';
 import { ClipboardMonitor } from './src/Manager/ClipboardMonitor.js';
 import { ClipboardPopup } from './src/UI/Popup.js';
@@ -27,6 +29,10 @@ export default class ClipMasterExtension extends Extension {
         this._settings = this.getSettings();
         this._extensionPath = this.path;
         this._signalManager = new SignalManager();
+        this._windowTracker = Shell.WindowTracker.get_default();
+        this._pendingPasteKeySpec = null;
+        this._previousFocusWindow = null;
+        this._previousFocusMeta = null;
 
         setDebugMode(this._settings.get_boolean('debug-mode'));
         this._signalManager.connect(
@@ -118,6 +124,9 @@ export default class ClipMasterExtension extends Extension {
         }
 
         setDebugMode(false);
+        this._pendingPasteKeySpec = null;
+        this._previousFocusWindow = null;
+        this._previousFocusMeta = null;
         this._settings = null;
 
         console.log('ClipMaster extension disabled');
@@ -184,6 +193,11 @@ export default class ClipMasterExtension extends Extension {
         }
 
         debugLog('showPopup: Starting to show popup');
+
+        // Save focused window so we can restore focus when popup closes.
+        this._previousFocusWindow = global.display.focus_window;
+        this._previousFocusMeta = this._getWindowMeta(this._previousFocusWindow);
+        this._pendingPasteKeySpec = null;
 
         // Add to chrome only when showing (prevents input blocking when hidden)
         if (!this._popupAddedToChrome) {
@@ -285,6 +299,8 @@ export default class ClipMasterExtension extends Extension {
                 debugLog('hidePopup: Removed popup from chrome');
             }
 
+            this._restorePreviousFocusAndMaybePaste();
+
             // Move off-screen as extra safety measure
             this._popup.set_position(-10000, -10000);
             debugLog('hidePopup: Popup hidden and moved off-screen');
@@ -308,6 +324,112 @@ export default class ClipMasterExtension extends Extension {
         const items = this._database.getItems({ limit: 1 });
         if (items.length > 0) {
             this._monitor.copyToClipboard(items[0].plainText, true);
+        }
+    }
+
+    queueAutoPasteForSelection() {
+        this._pendingPasteKeySpec = getPasteKeySpec(this._previousFocusMeta || {});
+        debugLog(`queueAutoPasteForSelection: queued ${this._pendingPasteKeySpec.label}`);
+    }
+
+    _getWindowMeta(window) {
+        if (!window) {
+            return null;
+        }
+
+        let app = null;
+        try {
+            app = this._windowTracker?.get_window_app(window) || null;
+        } catch (e) {
+            debugLog(`_getWindowMeta: Failed to read window app: ${e.message}`);
+        }
+
+        return {
+            appId: app?.get_id?.() || '',
+            wmClass: window.get_wm_class?.() || '',
+            wmClassInstance: window.get_wm_class_instance?.() || '',
+            title: window.get_title?.() || '',
+        };
+    }
+
+    _restorePreviousFocusAndMaybePaste() {
+        const win = this._previousFocusWindow;
+        const pendingPasteKeySpec = this._pendingPasteKeySpec;
+
+        this._previousFocusWindow = null;
+        this._previousFocusMeta = null;
+        this._pendingPasteKeySpec = null;
+
+        if (!win && !pendingPasteKeySpec) {
+            return;
+        }
+
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+            try {
+                if (win && win.activate) {
+                    win.activate(global.get_current_time());
+                    debugLog('hidePopup: Restored focus to previous window');
+                }
+            } catch (e) {
+                debugLog(`hidePopup: Failed to restore focus: ${e.message}`);
+            }
+
+            if (pendingPasteKeySpec) {
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 75, () => {
+                    if (global.display.focus_window) {
+                        this._sendPasteShortcut(pendingPasteKeySpec);
+                    } else {
+                        debugLog('_restorePreviousFocusAndMaybePaste: Skipping paste shortcut because no window has focus');
+                    }
+                    return GLib.SOURCE_REMOVE;
+                });
+            }
+
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _sendPasteShortcut(keySpec) {
+        const keyboard = this._createVirtualKeyboard();
+        if (!keyboard) {
+            debugLog('_sendPasteShortcut: No virtual keyboard available');
+            return false;
+        }
+
+        const modifierKeys = Array.isArray(keySpec.modifiers) ? keySpec.modifiers : [];
+        if (!keySpec.keycode) {
+            debugLog('_sendPasteShortcut: Missing hardware keycode');
+            return false;
+        }
+
+        let timestamp = GLib.get_monotonic_time();
+
+        for (const modifierKey of modifierKeys) {
+            keyboard.notify_key(timestamp, modifierKey, Clutter.KeyState.PRESSED);
+            timestamp += 1000;
+        }
+
+        keyboard.notify_key(timestamp, keySpec.keycode, Clutter.KeyState.PRESSED);
+        timestamp += 1000;
+        keyboard.notify_key(timestamp, keySpec.keycode, Clutter.KeyState.RELEASED);
+        timestamp += 1000;
+
+        for (const modifierKey of [...modifierKeys].reverse()) {
+            keyboard.notify_key(timestamp, modifierKey, Clutter.KeyState.RELEASED);
+            timestamp += 1000;
+        }
+
+        debugLog(`_sendPasteShortcut: Sent ${keySpec.label}`);
+        return true;
+    }
+
+    _createVirtualKeyboard() {
+        try {
+            const seat = Clutter.get_default_backend()?.get_default_seat?.();
+            return seat?.create_virtual_device?.(Clutter.InputDeviceType.KEYBOARD_DEVICE) || null;
+        } catch (e) {
+            debugLog(`_createVirtualKeyboard: ${e.message}`);
+            return null;
         }
     }
 }

--- a/clipmaster@gnome.extension/src/Manager/ClipboardMonitor.js
+++ b/clipmaster@gnome.extension/src/Manager/ClipboardMonitor.js
@@ -686,6 +686,7 @@ export class ClipboardMonitor {
         }
         this._lastContent = text;
         this._clipboard.set_text(St.ClipboardType.CLIPBOARD, text);
+        this._clipboard.set_text(St.ClipboardType.PRIMARY, text);
     }
 
     async copyImageToClipboard(imageContent) {

--- a/clipmaster@gnome.extension/src/UI/Popup.js
+++ b/clipmaster@gnome.extension/src/UI/Popup.js
@@ -997,6 +997,11 @@ export const ClipboardPopup = GObject.registerClass(
             this.opacity = 0;
             this.reactive = false;
 
+            // Release shell key focus so the previously active app can receive paste shortcuts.
+            if (global.stage?.get_key_focus?.()) {
+                global.stage.set_key_focus(null);
+            }
+
             // Move off-screen as safety measure
             this.set_position(-10000, -10000);
 
@@ -1007,6 +1012,7 @@ export const ClipboardPopup = GObject.registerClass(
             if (this._signalManager) {
                 // Disconnect all known global stage handlers
                 this._signalManager.disconnect('click-outside-handler');
+                this._signalManager.disconnect('focus-window-handler');
                 this._signalManager.disconnect('drag-motion');
                 this._signalManager.disconnect('drag-release');
                 debugLog('All global handlers disconnected');
@@ -1445,7 +1451,7 @@ export const ClipboardPopup = GObject.registerClass(
             });
         }
 
-        _pasteSelected() {
+        async _pasteSelected() {
             debugLog(`=== _pasteSelected() CALLED ===`);
             debugLog(`Items length: ${this._items.length}, selectedIndex: ${this._selectedIndex}`);
 
@@ -1460,7 +1466,7 @@ export const ClipboardPopup = GObject.registerClass(
 
             if (item.type === ItemType.IMAGE && item.content) {
                 debugLog(`Copying image to clipboard: ${item.content}`);
-                this._monitor.copyImageToClipboard(item.content);
+                await this._monitor.copyImageToClipboard(item.content);
             } else {
                 const content = this._plainTextMode ? item.plainText : item.content;
                 debugLog(`Copying text to clipboard (plainText=${this._plainTextMode}): ${content ? content.substring(0, 50) : 'null'}...`);
@@ -1481,6 +1487,7 @@ export const ClipboardPopup = GObject.registerClass(
             debugLog(`close-on-paste=${closeOnPaste}, _isPinned=${this._isPinned}, isFromHover=${isFromHover}`);
 
             if (closeOnPaste && !this._isPinned && !isFromHover) {
+                this._extension.queueAutoPasteForSelection();
                 debugLog(`Closing popup after paste (close-on-paste=true, not pinned, explicit click)`);
                 this._extension.hidePopup();
             } else {

--- a/clipmaster@gnome.extension/src/Util/PasteUtils.js
+++ b/clipmaster@gnome.extension/src/Util/PasteUtils.js
@@ -1,0 +1,53 @@
+const TERMINAL_IDENTIFIERS = [
+    'org.gnome.terminal',
+    'org.gnome.console',
+    'ptyxis',
+    'tilix',
+    'alacritty',
+    'kitty',
+    'wezterm',
+    'konsole',
+    'xterm',
+];
+
+const SHIFT_LEFT = 42;
+const CTRL_LEFT = 29;
+const INSERT_KEY = 110;
+const V_KEY = 47;
+
+function normalize(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+export function isTerminalWindow(meta = {}) {
+    const candidates = [
+        normalize(meta.appId),
+        normalize(meta.wmClass),
+        normalize(meta.wmClassInstance),
+        normalize(meta.title),
+    ].filter(Boolean);
+
+    return candidates.some(candidate =>
+        TERMINAL_IDENTIFIERS.some(identifier =>
+            candidate === identifier ||
+            candidate.includes(identifier) ||
+            candidate.endsWith(`${identifier}.desktop`)
+        )
+    );
+}
+
+export function getPasteKeySpec(meta = {}) {
+    if (isTerminalWindow(meta)) {
+        return {
+            modifiers: [CTRL_LEFT, SHIFT_LEFT],
+            keycode: V_KEY,
+            label: 'Ctrl+Shift+V',
+        };
+    }
+
+    return {
+        modifiers: [SHIFT_LEFT],
+        keycode: INSERT_KEY,
+        label: 'Shift+Insert',
+    };
+}

--- a/clipmaster@gnome.extension/tests/paste-utils.test.mjs
+++ b/clipmaster@gnome.extension/tests/paste-utils.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getPasteKeySpec, isTerminalWindow } from '../src/Util/PasteUtils.js';
+
+const SHIFT_LEFT = 42;
+const CTRL_LEFT = 29;
+const INSERT_KEY = 110;
+const V_KEY = 47;
+
+test('detects terminal windows from app id', () => {
+    assert.equal(isTerminalWindow({ appId: 'org.gnome.Terminal' }), true);
+    assert.equal(isTerminalWindow({ appId: 'org.gnome.Console' }), true);
+    assert.equal(isTerminalWindow({ appId: 'firefox.desktop' }), false);
+});
+
+test('detects terminal windows from wm class', () => {
+    assert.equal(isTerminalWindow({ wmClass: 'kitty' }), true);
+    assert.equal(isTerminalWindow({ wmClass: 'Alacritty' }), true);
+    assert.equal(isTerminalWindow({ wmClass: 'Code' }), false);
+});
+
+test('uses terminal-specific paste shortcuts', () => {
+    assert.deepEqual(getPasteKeySpec({ appId: 'org.gnome.Terminal' }), {
+        modifiers: [CTRL_LEFT, SHIFT_LEFT],
+        keycode: V_KEY,
+        label: 'Ctrl+Shift+V',
+    });
+
+    assert.deepEqual(getPasteKeySpec({ appId: 'firefox.desktop' }), {
+        modifiers: [SHIFT_LEFT],
+        keycode: INSERT_KEY,
+        label: 'Shift+Insert',
+    });
+});


### PR DESCRIPTION
## Summary
- restore focus to the previously active window after closing the ClipMaster popup
- auto-paste selected clipboard items on Wayland using GNOME's virtual keyboard
- use terminal-aware paste shortcuts and update both CLIPBOARD and PRIMARY for text selections